### PR TITLE
Update pipenv install step to install to system

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --upgrade pipenv wheel
     - name: Install dependencies
       run: |
-        pipenv install --deploy
+        pipenv install --deploy --system
 
     # Build the book
     - name: Build the book


### PR DESCRIPTION
github action fails (unable to find jupyter-book installed) as dependencies are installed in virtualenv instead of system python env. this pr updates the github actions workflow to install deps directly to system python